### PR TITLE
[RLDM-6] [Imóveis] Ajustes de formatação na descrição do imóveis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@splidejs/react-splide": "^0.7.12",
+        "markdown-to-jsx": "^7.4.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.16.0",
@@ -4697,6 +4698,17 @@
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/markdown-to-jsx": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.7.tgz",
+      "integrity": "sha512-0+ls1IQZdU6cwM1yu0ZjjiVWYtkbExSyUIFU2ZeDIFuZM1W42Mh4OlJ4nb4apX4H8smxDHRdFaoIVJGwfv5hkg==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0"
       }
     },
     "node_modules/merge-stream": {
@@ -9427,6 +9439,12 @@
           "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
       }
+    },
+    "markdown-to-jsx": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.7.tgz",
+      "integrity": "sha512-0+ls1IQZdU6cwM1yu0ZjjiVWYtkbExSyUIFU2ZeDIFuZM1W42Mh4OlJ4nb4apX4H8smxDHRdFaoIVJGwfv5hkg==",
+      "requires": {}
     },
     "merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@splidejs/react-splide": "^0.7.12",
+    "markdown-to-jsx": "^7.4.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",

--- a/src/data/RealStateData.js
+++ b/src/data/RealStateData.js
@@ -26,7 +26,7 @@ const properties = [
     title: 'Brisamar',
     region: 'Ingleses',
     description:
-      'IMÓVEL COM MATRÍCULA. Lindo e amplo apartamento, dois dormitórios, sendo 1 suíte, sacada com churrasqueira, totalmente mobiliado em condomínio com piscina, numa das melhores ruas da Praia dos Ingleses. Localizado a 500 mts do mar.',
+      '**IMÓVEL COM MATRÍCULA**\n\n Lindo e amplo apartamento, dois dormitórios, sendo 1 suíte, sacada com churrasqueira, totalmente mobiliado em condomínio com piscina, numa das melhores ruas da Praia dos Ingleses. Localizado a 500 mts do mar.',
     price: 'R$ 650.000,00',
     details: {
       square: '78,52 m²',
@@ -49,7 +49,7 @@ const properties = [
     title: 'Ilha das Galés',
     region: 'Ingleses',
     description:
-      'IMÓVEL COM MATRÍCULA. Maravilhosa cobertura com 4 dormitórios sendo 3 suítes, amplo terraço com piscina, sala dois ambientes, totalmente mobiliada, com vista mar, localizada na parte nobre do bairro e a uma quadra da praia.',
+      '**IMÓVEL COM MATRÍCULA**\n\n Maravilhosa cobertura com 4 dormitórios sendo 3 suítes, amplo terraço com piscina, sala dois ambientes, totalmente mobiliada, com vista mar, localizada na parte nobre do bairro e a uma quadra da praia.',
     price: 'R$ 2.600.000,00',
     details: {
       square: '235,47 m²',
@@ -72,7 +72,7 @@ const properties = [
     title: 'Ponta do Mar',
     region: 'Ingleses',
     description:
-      'IMÓVEL COM MATRÍCULA! Imperdível! Se você está procurando um apartamento amplo e próximo ao mar, esse é o imóvel certo. Apartamento mobiliado, com 3 dormitórios, sendo uma suíte com sacada, cozinha planejada integrada à sala, varanda espaçosa com churrasqueira a carvão, uma vaga de garagem e hobby box. O condomínio oferece piscina, salão de festas, elevador e segurança.',
+      '**IMÓVEL COM MATRÍCULA**\n\n Imperdível! Se você está procurando um apartamento amplo e próximo ao mar, esse é o imóvel certo. Apartamento mobiliado, com 3 dormitórios, sendo uma suíte com sacada, cozinha planejada integrada à sala, varanda espaçosa com churrasqueira a carvão, uma vaga de garagem e hobby box. O condomínio oferece piscina, salão de festas, elevador e segurança.',
     price: 'R$ 739.000,00',
     details: {
       square: '105,30 m²',

--- a/src/presentation/pages/Properties/components/PropertyCard/index.jsx
+++ b/src/presentation/pages/Properties/components/PropertyCard/index.jsx
@@ -17,6 +17,8 @@ import squareIcon from '../../../../assets/square-icon.svg'
 import showerIcon from '../../../../assets/shower-icon.svg'
 import { SplideSlide } from '@splidejs/react-splide'
 
+import Markdown from 'markdown-to-jsx'
+
 import { useState } from 'react'
 
 const IconsMap = {
@@ -81,7 +83,12 @@ export function PropertyCard({
             ))}
         </Tags>
         <Description>
-          <p>{propertyInfo.description}</p>
+          <Markdown
+            options={{ disableParsingRawHTML: true }}
+            className="description-text"
+          >
+            {propertyInfo.description}
+          </Markdown>
           <p>
             <small>Informações sujeitas a alterações sem aviso prévio.</small>
           </p>


### PR DESCRIPTION
Instalando biblioteca markdown-to-jsx e aplicando novas configurações para colocar as primeiras duas palavras "IMÓVEL COM MATRÍCULA" em negrito e pular linha.